### PR TITLE
Pseudo was necessary to create a new user

### DIFF
--- a/nestedworld_api/views/api/v1/user/auth.py
+++ b/nestedworld_api/views/api/v1/user/auth.py
@@ -84,6 +84,8 @@ class Register(Resource):
         'email', type=str, required=True, help='User email', location='form')
     parser.add_argument(
         'password', type=str, required=True, help='User password', location='form')
+    parser.add_argument(
+        'pseudo', type=str, required=True, help='User pseudonyme', location='form')
 
     result = auth.model('User', {
         'email': fields.String(required=True, description='User email'),
@@ -107,6 +109,7 @@ class Register(Resource):
         user = User()
         user.email = args.email
         user.password = args.password
+        user.pseudo = args.pseudo
         user.is_activated = True # TODO: Send activation email
 
         db.session.add(user)


### PR DESCRIPTION
We could not create a new user because of the form which did not include the user field
